### PR TITLE
UI improvements

### DIFF
--- a/code/Controller.php
+++ b/code/Controller.php
@@ -560,11 +560,11 @@ class Controller {
             $trans = array(
                 'ESTODAY' => toDate(time(), 'd.m.Y'),
                 'ESDATE' => toDate($activeEvent->getDateFrom(), 'd.m.Y'),
-                'ESFIRSTNAME' => escape($student->getFirstName()),
-                'ESLASTNAME' => escape($student->getLastName()),
-                'ESUSERNAME' => escape($student->getUserName()),
-                'ESCLASS' => escape($student->getClass()),
-                'ESPASSWORD' => escape($password)
+                'ESFIRSTNAME' => escape_xml($student->getFirstName()),
+                'ESLASTNAME' => escape_xml($student->getLastName()),
+                'ESUSERNAME' => escape_xml($student->getUserName()),
+                'ESCLASS' => escape_xml($student->getClass()),
+                'ESPASSWORD' => escape_xml($password)
             );
 
             $copyNode = $copyNodeBackup->cloneNode(true);

--- a/code/Util.php
+++ b/code/Util.php
@@ -6,6 +6,10 @@ function escape($string) {
 	return nl2br(htmlentities($string));
 }
 
+function escape_xml($string) {
+	return nl2br(htmlentities($string, ENT_XML1 | ENT_SUBSTITUTE));
+}
+
 class SessionContext {
 	private static $isCreated = false;
 	

--- a/code/dao/UserDAO.php
+++ b/code/dao/UserDAO.php
@@ -34,7 +34,7 @@ class UserDAO extends AbstractDAO {
         $con = self::getConnection();
         $params = array($type);
 
-        $orderPhrase = 'ORDER BY lastName';
+        $orderPhrase = 'ORDER BY lastName COLLATE utf8_general_ci';
         $query = sprintf('SELECT id, userName, passwordHash, firstName, lastName, class, role, title, absent FROM user WHERE role = ? %s;', $orderPhrase);
         if ($limit > 0) {
            $query = 'SELECT id, userName, passwordHash, firstName, lastName, class, role, title, absent FROM user WHERE role = ? ORDER BY lastName LIMIT 10';

--- a/home.php
+++ b/home.php
@@ -1,3 +1,25 @@
+<?php 
+require_once('code/Util.php');
+require_once('code/dao/AbstractDAO.php');
+require_once('code/AuthenticationManager.php');
+
+SessionContext::create();
+
+if (!isset($_SESSION['userId'])) {
+    header('Location: index.php');
+}
+
+$user = AuthenticationManager::getAuthenticatedUser();
+
+if ($user->getRole() === 'admin') {
+	header('Location: admin.php');
+	die();
+}
+if ($user->getRole() === 'teacher') {
+	header('Location: teacher.php');
+	die();
+}
+?>
 <?php include_once 'inc/header.php'; ?>
 
 <script type='text/javascript' src='js/mySlots.js'></script>
@@ -28,6 +50,13 @@
         </button>
 
         <div id='timeTable' class="section-to-print"></div>
+
+    </div>
+</div>
+
+<div class='container'>
+    <div id='tabs-1'>
+        <h3>Wechseln Sie oben auf „<a href="book.php">Zeiten buchen</a>“ um Sprechtermine zu reservieren.</h3>
     </div>
 </div>
 

--- a/inc/navBar.php
+++ b/inc/navBar.php
@@ -13,8 +13,10 @@
         <div id='navbar' class='navbar-collapse collapse'>
 
             <ul class='nav navbar-nav'>
+	    	<?php if ($user->getRole() === 'student') { ?>
                 <li id='navTabHome'><a href='home.php'>Gebuchte Zeiten</a></li>
                 <li id='navTabBook'><a href='book.php'>Zeiten buchen</a></li>
+		<?php } ?>
                 <?php if ($user->getRole() === 'teacher') { ?>
                     <li id='navTabTeacher'><a href='teacher.php'>Übersicht</a></li>
                 <?php } ?>


### PR DESCRIPTION
When we set up speechday for our use case, We saw that teachers are also able to book time slots of other teachers. We wanted that when teachers log in, they should see their timetable as a host and not the useless empty one. So we did a redirection (ugly implementation) and remove the unnecessary entries from the menu.
Also, a hint for newbies what they ca do here on the home page was introduced.
We have a teacher with a surname-prefix ("di" in our case) and it was sorted to the end of the list. So I implemented utf8_general_ci collation for this query to get case insensitive sorting.